### PR TITLE
fix: break down test

### DIFF
--- a/src/components/events/select/duration/duration.test.tsx
+++ b/src/components/events/select/duration/duration.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { Duration } from '.'
+
+const mockIsMidnightToMidnight = jest.fn()
+const mockParseEventDateFieldToDateTime = jest.fn()
+
+jest.mock('../../../../utils/date-helpers', () => ({
+  isMidnightToMidnight: () => mockIsMidnightToMidnight(),
+  parseEventDateFieldToDateTime: () => mockParseEventDateFieldToDateTime(),
+}))
+
+describe('components/events/select/duration/duration.tsx', () => {
+  it('should render All Day for no datetime', () => {
+    mockIsMidnightToMidnight.mockReturnValueOnce(false)
+    mockParseEventDateFieldToDateTime.mockReturnValue(new Date(2024, 1, 1, 0, 0, 0))
+
+    render(<Duration start={{}} end={{}} />)
+
+    expect(screen.getByText('All Day')).toBeInTheDocument()
+  })
+
+  it('should render All Day for midnight to midnight', () => {
+    mockIsMidnightToMidnight.mockReturnValueOnce(true)
+    mockParseEventDateFieldToDateTime.mockReturnValue(new Date(2024, 1, 1, 0, 0, 0))
+
+    render(<Duration start={{ dateTime: 'foo' }} end={{ dateTime: 'bar' }} />)
+
+    expect(screen.getByText('All Day')).toBeInTheDocument()
+    expect(screen.queryByText(/\+1/)).not.toBeInTheDocument()
+  })
+
+  it('should render superscript', () => {
+    mockIsMidnightToMidnight.mockReturnValueOnce(false)
+    mockParseEventDateFieldToDateTime.mockReturnValueOnce(new Date(2024, 1, 1, 10, 0, 0))
+    mockParseEventDateFieldToDateTime.mockReturnValueOnce(new Date(2024, 1, 3, 14, 0, 0))
+
+    render(<Duration start={{ dateTime: 'foo' }} end={{ dateTime: 'bar' }} />)
+
+    expect(screen.queryByText('All Day')).not.toBeInTheDocument()
+    expect(screen.getByText(/\+2/)).toBeInTheDocument()
+  })
+
+  it('should render superscript for midnight to midnight & duration.days 1 2', () => {
+    mockIsMidnightToMidnight.mockReturnValueOnce(true)
+    mockParseEventDateFieldToDateTime.mockReturnValueOnce(new Date(2024, 1, 1, 0, 0, 0))
+    mockParseEventDateFieldToDateTime.mockReturnValueOnce(new Date(2024, 1, 3, 0, 0, 0))
+
+    render(<Duration start={{ dateTime: 'foo' }} end={{ dateTime: 'bar' }} />)
+
+    expect(screen.getByText('All Day')).toBeInTheDocument()
+    expect(screen.getByText(/\+2/)).toBeInTheDocument()
+  })
+})

--- a/src/test/events/select/page.test.tsx
+++ b/src/test/events/select/page.test.tsx
@@ -47,16 +47,6 @@ describe('app/events/select/page', () => {
     })
   })
 
-  it.failing('should render all day event durations', async () => {
-    mockGetEvents.mockResolvedValueOnce({ events: mockEvents })
-
-    await waitFor(() => render(<Select />))
-
-    expect(await screen.findAllByText('All Day')).toHaveLength(2)
-    expect(await screen.findAllByText('+1')).toHaveLength(1)
-    expect(await screen.findAllByText('+2')).toHaveLength(1)
-  })
-
   it('should handle shift selection - EventCheckbox', async () => {
     mockGetEvents.mockResolvedValueOnce({ events: mockEvents })
 

--- a/src/utils/date-helpers.test.tsx
+++ b/src/utils/date-helpers.test.tsx
@@ -1,0 +1,9 @@
+import { isMidnightToMidnight } from './date-helpers'
+
+describe('utils/date-helpers', () => {
+  it('should return true if midnight', () => {
+    const start = new Date(2024, 1, 1, 0, 0, 0)
+    const end = new Date(2024, 1, 2, 0, 0, 0)
+    expect(isMidnightToMidnight(start, end)).toBe(true)
+  })
+})


### PR DESCRIPTION
- move duration string checks to a unit test of the duration component
- check isMidnightToMidnight in a date-helpers test