### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,8 @@ name: Coverage
 on: [push, pull_request, workflow_dispatch]
 jobs:
   coverage:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/lambersond/google-calendar-sync/security/code-scanning/1](https://github.com/lambersond/google-calendar-sync/security/code-scanning/1)

In general, the fix is to add a `permissions` block to the workflow or to the specific job to restrict `GITHUB_TOKEN` to the least privileges required. For a coverage workflow that mostly reads code and then updates a coverage badge, we can grant `contents: read` at the workflow/job level, and then add a more permissive, narrowly scoped permission only where write access is required (e.g., `contents: write` on the job if the external action needs to push badge updates). This documents the intent and ensures the workflow remains least-privilege even if repo/org defaults change.

In this specific file `.github/workflows/coverage.yml`, the simplest non-breaking change is to add a `permissions` block under the `coverage` job. At minimum, `actions/checkout` requires `contents: read`. The `we-cli/coverage-badge-action@main` step almost certainly needs to write to repository contents (e.g., updating a badge file and pushing a commit), which usually uses `contents: write`. To avoid changing existing behavior, we should grant `contents: write` at the job level rather than trying to over-restrict and risk breaking the badge update. Concretely, insert:

```yaml
permissions:
  contents: write
```

immediately under `coverage:` and above `runs-on: ubuntu-latest`. No imports or extra files are needed; it’s purely a YAML configuration change in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
